### PR TITLE
Fix embeds_one functionality

### DIFF
--- a/lib/mongoid/delorean/trackable.rb
+++ b/lib/mongoid/delorean/trackable.rb
@@ -52,7 +52,7 @@ module Mongoid
       end
 
       module CommonEmbeddedMethods
-        
+
         def save_version
           self._parent.save_version if self._parent.respond_to?(:save_version)
         end
@@ -73,9 +73,13 @@ module Mongoid
           self.embedded_relations.each do |name, details|
             relation = self.send(name)
             relation_changes[name] = []
-            r_changes = relation.map {|o| o.changes_with_relations}
-            relation_changes[name] << r_changes unless r_changes.empty?
-            relation_changes[name].flatten!
+            if relation and relation.metadata.relation == Mongoid::Relations::Embedded::One
+              relation_changes[name] = relation.changes_with_relations
+            else
+              r_changes = relation.map {|o| o.changes_with_relations}
+              relation_changes[name] << r_changes unless r_changes.empty?
+              relation_changes[name].flatten!
+            end
             relation_changes.delete(name) if relation_changes[name].empty?
           end
 
@@ -85,15 +89,19 @@ module Mongoid
 
         def attributes_with_relations
           _attributes = self.attributes.dup
-          
+
           relation_attrs = {}
           self.embedded_relations.each do |name, details|
             relation = self.send(name)
             relation_attrs[name] = []
-            r_attrs = relation.map {|o| o.attributes_with_relations}
-            relation_attrs[name] << r_attrs unless r_attrs.empty?
-            r_changes = relation.map {|o| o.changes}
-            relation_attrs[name].flatten!
+            if relation and relation.metadata.relation == Mongoid::Relations::Embedded::One
+              relation_attrs[name] = relation.attributes_with_relations
+            else
+              r_attrs = relation.map {|o| o.attributes_with_relations}
+              relation_attrs[name] << r_attrs unless r_attrs.empty?
+              r_changes = relation.map {|o| o.changes}
+              relation_attrs[name].flatten!
+            end
           end
           _attributes.merge!(relation_attrs)
           return _attributes

--- a/lib/mongoid/delorean/trackable.rb
+++ b/lib/mongoid/delorean/trackable.rb
@@ -93,10 +93,10 @@ module Mongoid
           relation_attrs = {}
           self.embedded_relations.each do |name, details|
             relation = self.send(name)
-            relation_attrs[name] = []
             if details.relation == Mongoid::Relations::Embedded::One
               relation_attrs[name] = relation.attributes_with_relations if relation
             else
+              relation_attrs[name] = []
               r_attrs = relation.map {|o| o.attributes_with_relations}
               relation_attrs[name] << r_attrs unless r_attrs.empty?
               r_changes = relation.map {|o| o.changes}

--- a/lib/mongoid/delorean/trackable.rb
+++ b/lib/mongoid/delorean/trackable.rb
@@ -73,8 +73,8 @@ module Mongoid
           self.embedded_relations.each do |name, details|
             relation = self.send(name)
             relation_changes[name] = []
-            if relation and relation.metadata.relation == Mongoid::Relations::Embedded::One
-              relation_changes[name] = relation.changes_with_relations
+            if details.relation == Mongoid::Relations::Embedded::One
+              relation_changes[name] = relation.changes_with_relations if relation
             else
               r_changes = relation.map {|o| o.changes_with_relations}
               relation_changes[name] << r_changes unless r_changes.empty?
@@ -94,8 +94,8 @@ module Mongoid
           self.embedded_relations.each do |name, details|
             relation = self.send(name)
             relation_attrs[name] = []
-            if relation and relation.metadata.relation == Mongoid::Relations::Embedded::One
-              relation_attrs[name] = relation.attributes_with_relations
+            if details.relation == Mongoid::Relations::Embedded::One
+              relation_attrs[name] = relation.attributes_with_relations if relation
             else
               r_attrs = relation.map {|o| o.attributes_with_relations}
               relation_attrs[name] << r_attrs unless r_attrs.empty?

--- a/spec/mongoid/delorean/trackable_spec.rb
+++ b/spec/mongoid/delorean/trackable_spec.rb
@@ -151,6 +151,12 @@ describe Mongoid::Delorean::Trackable do
 
       version = a.versions.last
       version.altered_attributes.should eql({"pages"=>[{"sections"=>[{"_id"=>[nil, section.id], "body"=>[nil, "some body text"]}]}], "version"=>[2, 3]})
+
+      footer = page.build_footer(:content => "some footer text")
+      a.save!
+
+      version = a.versions.last
+      version.altered_attributes.should eql({"pages"=>[{"sections"=>[{}], "footer"=>{"_id"=>[nil, footer.id], "content"=>[nil, "some footer text"]}}], "version"=>[3, 4]})
     end
 
     it "tracks the full set of attributes at the time of saving" do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -27,9 +27,17 @@ class Page
 
   embedded_in :article, inverse_of: :pages
   embeds_many :sections
+  embeds_one :footer
 end
 
+class Footer
+  include Mongoid::Document
+  include Mongoid::Timestamps
 
+  field :content, type: String
+
+  embedded_in :page
+end
 
 class User
   include Mongoid::Document


### PR DESCRIPTION
This fixes `embeds_one` relationships. They previously caused Mongoid Deloreon to throw errors. @felipero / @crafters actually did the fix, I just found the fork and the fixes worked for me, so it might be nice to get this fixed upstream if possible. I added tests around this functionality, and also tweaked one little thing with @felipero's original code (so an empty embeds_one associations remains nil, rather than becoming an empty array).
