### PR TITLE
Fix save(validate: false) not properly skipping validations

### DIFF
--- a/lib/mongoid/delorean/trackable.rb
+++ b/lib/mongoid/delorean/trackable.rb
@@ -62,11 +62,15 @@ module Mongoid
         
         def save_version
           if self._parent.respond_to?(:save_version)
-            if self._parent.track_history?
-              self._parent.save_version
-              self._parent.without_history_tracking do
-                self._parent.save!(validate: false)
+            if self._parent.respond_to?(:track_history?)
+              if self._parent.track_history?
+                self._parent.save_version
+                self._parent.without_history_tracking do
+                  self._parent.save!(validate: false)
+                end
               end
+            else
+              self._parent.save_version
             end
           end
 

--- a/lib/mongoid/delorean/trackable.rb
+++ b/lib/mongoid/delorean/trackable.rb
@@ -6,6 +6,7 @@ module Mongoid
         super
         klass.field :version, type: Integer, default: 0
         klass.before_save :save_version
+        klass.after_save :after_save_version
         klass.send(:include, Mongoid::Delorean::Trackable::CommonInstanceMethods)
       end
 
@@ -25,7 +26,15 @@ module Mongoid
 
           Mongoid::Delorean::History.create(original_class: self.class.name, original_class_id: self.id, version: _version, altered_attributes: _changes, full_attributes: _attributes)
           self.version = _version
+
+          @__track_changes = false
         end
+
+        true
+      end
+
+      def after_save_version
+        @__track_changes = Mongoid::Delorean.config.track_history
       end
 
       def track_history?
@@ -33,9 +42,10 @@ module Mongoid
       end
 
       def without_history_tracking
+        previous_track_change = @__track_changes
         @__track_changes = false
         yield
-        @__track_changes = Mongoid::Delorean.config.track_history
+        @__track_changes = previous_track_change
       end
 
       def revert!(version = (self.version - 1))
@@ -52,11 +62,15 @@ module Mongoid
         
         def save_version
           if self._parent.respond_to?(:save_version)
-            self._parent.save_version
-            self._parent.without_history_tracking do
-              self._parent.save!(validate: false)
+            if self._parent.track_history?
+              self._parent.save_version
+              self._parent.without_history_tracking do
+                self._parent.save!(validate: false)
+              end
             end
           end
+
+          true
         end
 
       end

--- a/spec/mongoid/delorean/trackable_spec.rb
+++ b/spec/mongoid/delorean/trackable_spec.rb
@@ -204,12 +204,31 @@ describe Mongoid::Delorean::Trackable do
       a = Article.new(name: "Article 1")
       a.authors.build(name: "John Doe")
       a.authors.build(name: "Jane Doe")
+      a.authors.last.influences.build(name: "Poe")
+      a.authors.last.influences.build(name: "Twain")
 
       a.save!
       a.version.should eql(1)
 
       a.authors.first.name = "Joe Blow"
       a.save!
+      a.reload
+      a.version.should eql(2)
+    end
+
+    it "saves parent versions when saving embedded documents multiple levels deep" do
+      a = Article.new(name: "Article 1")
+      page = a.pages.build(name: "Page 1")
+      section = page.sections.build(body: "some body text")
+
+      a.save!
+      a.version.should eql(1)
+
+      a.reload
+      section = a.pages.first.sections.first
+      section.body = "updated body text"
+      section.save!
+
       a.reload
       a.version.should eql(2)
     end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -18,6 +18,7 @@ class Article
   field :publish_year, type: String
 
   embeds_many :pages
+  embeds_many :authors, cascade_callbacks: true
 
   validates :publish_year, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 end
@@ -35,7 +36,14 @@ class Page
   validates :number, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 end
 
+class Author
+  include Mongoid::Document
+  include Mongoid::Timestamps
 
+  field :name, type: String
+
+  embedded_in :article, inverse_of: :authors
+end
 
 class User
   include Mongoid::Document

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -15,8 +15,11 @@ class Article
 
   field :name, type: String
   field :summary, type: String
+  field :publish_year, type: String
 
   embeds_many :pages
+
+  validates :publish_year, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 end
 
 class Page
@@ -24,9 +27,12 @@ class Page
   include Mongoid::Timestamps
 
   field :name, type: String
+  field :number, type: Integer
 
   embedded_in :article, inverse_of: :pages
   embeds_many :sections
+
+  validates :number, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 end
 
 
@@ -38,4 +44,7 @@ class User
 
   field :name, type: String
   field :age, type: Integer
+  field :email, type: String
+
+  validates :email, format: { with: /.+@.+\..+/, allow_nil: true }
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -42,7 +42,17 @@ class Author
 
   field :name, type: String
 
+  embeds_many :influences, cascade_callbacks: true
   embedded_in :article, inverse_of: :authors
+end
+
+class Influence
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+
+  embedded_in :author
 end
 
 class User


### PR DESCRIPTION
`save(validate: false)` on a record wasn't properly working, since there was a plain `save!` always being called inside the `before_save` callback for every record. That callback had the effect of forcing validations on each record's save, since any options you passed into your own save call weren't be honored inside the callback's save call.

This approach fixes the issue by not forcing a save during the `before_save` callback phase. That way the options passed into your own save call still take precedent. An explicit save during the callback phase is still necessary on parent records when saving an embedded record, but that save is now being done without validations turned on (since that save is effectively only updating the `version` attribute on the parent record).

I added tests around the different scenarios I had encountered, and this behavior now seems to match Mongoid's default save and validate behavior, but let me know if you had any different thoughts on how to tackle this.
