### PR TITLE
Fix saving versions when safe mode is enabled

### DIFF
--- a/lib/mongoid/delorean/trackable.rb
+++ b/lib/mongoid/delorean/trackable.rb
@@ -26,7 +26,9 @@ module Mongoid
           Mongoid::Delorean::History.create(original_class: self.class.name, original_class_id: self.id, version: _version, altered_attributes: _changes, full_attributes: _attributes).inspect
           self.without_history_tracking do
             self.version = _version
-            self.save!
+            unless(self.new_record?)
+              self.set(:version, _version)
+            end
           end
         end
       end

--- a/spec/config.yml
+++ b/spec/config.yml
@@ -4,3 +4,8 @@ test:
       database: mongoid_delorean_test
       hosts:
         - localhost:27017
+      options:
+        safe: true
+        consistency: :strong
+        max_retries: 1
+        retry_interval: 0


### PR DESCRIPTION
When the [safe mode option](http://mongoid.org/en/mongoid/docs/tips.html#safe_mode) is enabled for Mongoid, all new records fail to save when Mongoid Delorean is also enabled (all but one of the tests fail as soon as safe mode is enabled).

The save being triggered in the before_save callback was leading 2 save attempts for each record - once during the before_save and then once again during the normal save process. This second, normal save was then failing because a record already existed in Mongo. When safe mode is not enabled, Mongo's second save was silently failing, but with safe mode turned on, this error means each save action will result in a failure.

Since the save was only needed to update the version number for existing records, this is solved by performing a separate atomic update to that version field during the callback. This only happens for updates, since this secondary save isn't needed for new records at all.
