### PR TITLE
Fixes #9 version numbering error where the version number was not always getting bumped up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (3.2.17)
-      activesupport (= 3.2.17)
+    activemodel (3.2.22)
+      activesupport (= 3.2.22)
       builder (~> 3.0.0)
-    activesupport (3.2.17)
+    activesupport (3.2.22)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     builder (3.0.4)

--- a/lib/mongoid/delorean/trackable.rb
+++ b/lib/mongoid/delorean/trackable.rb
@@ -11,7 +11,7 @@ module Mongoid
       end
 
       def versions
-        Mongoid::Delorean::History.where(original_class: self.class.name, original_class_id: self.id)
+        Mongoid::Delorean::History.where(original_class: self.class.name, original_class_id: self.id).order_by(version: 'asce')
       end
 
       def save_version


### PR DESCRIPTION
Fixes #9: Modified Gemfile.lock to use Rails 3.2.22 because 3.2.17 was incompatible with Ruby 2.2 for some reason and modified trackable.rb to sort the Mongoid::Delorean::History objects by version before grabbing versions.last to ensure the new version number is correctly incrementing the latest version number by one